### PR TITLE
currentSongTimeをperformanceで送るように変更

### DIFF
--- a/HttpSiraStatus/HttpSiraStatus.csproj
+++ b/HttpSiraStatus/HttpSiraStatus.csproj
@@ -52,7 +52,7 @@
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Colors">
-      <HintPath>D:\Oculus\Software\hyperbolic-magnetism-beat-saber\Beat Saber_Data\Managed\Colors.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Colors.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="GameplayCore">

--- a/HttpSiraStatus/HttpSiraStatus.csproj.user
+++ b/HttpSiraStatus/HttpSiraStatus.csproj.user
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <BeatSaberDir>D:\Oculus\Software\hyperbolic-magnetism-beat-saber</BeatSaberDir>
-  </PropertyGroup>
-</Project>

--- a/HttpSiraStatus/Models/GamePlayDataManager.cs
+++ b/HttpSiraStatus/Models/GamePlayDataManager.cs
@@ -435,7 +435,7 @@ namespace HttpSiraStatus.Models
             var songTime = Mathf.FloorToInt(this.audioTimeSource.songTime);
             if (this.statusManager.GameStatus.currentSongTime != songTime) {
                 this.statusManager.GameStatus.currentSongTime = songTime;
-                this.statusManager.EmitStatusUpdate(ChangedProperty.Beatmap, BeatSaberEvent.BeatmapEvent);
+                this.statusManager.EmitStatusUpdate(ChangedProperty.Performance, BeatSaberEvent.BeatmapEvent);
             }
         }
 

--- a/HttpSiraStatus/Models/GameStatus.cs
+++ b/HttpSiraStatus/Models/GameStatus.cs
@@ -42,7 +42,6 @@ namespace HttpSiraStatus
         public Color? colorEnvironmentBoost0 = null;
         public Color? colorEnvironmentBoost1 = null;
         public Color? colorObstacle = null;
-        public int currentSongTime = 0;
 
         // Performance
         public int rawScore = 0;
@@ -63,6 +62,7 @@ namespace HttpSiraStatus
         public float energy = 0;
         public bool softFailed = false;
         public float relativeScore = 1;
+        public int currentSongTime = 0;
 
         // Note cut
         public int noteID = -1;
@@ -161,7 +161,6 @@ namespace HttpSiraStatus
             this.colorEnvironmentBoost0 = null;
             this.colorEnvironmentBoost1 = null;
             this.colorObstacle = null;
-            this.currentSongTime = 0;
         }
 
         public void ResetPerformance()
@@ -184,6 +183,7 @@ namespace HttpSiraStatus
             this.energy = 0;
             this.softFailed = false;
             this.relativeScore = 1;
+            this.currentSongTime = 0;
         }
 
         public void ResetNoteCut()

--- a/HttpSiraStatus/Models/StatusManager.cs
+++ b/HttpSiraStatus/Models/StatusManager.cs
@@ -158,7 +158,6 @@ namespace HttpSiraStatus
             beatmapJSON["maxScore"] = this.GameStatus.maxScore;
             beatmapJSON["maxRank"] = this.GameStatus.maxRank;
             beatmapJSON["environmentName"] = this.GameStatus.environmentName;
-            beatmapJSON["currentSongTime"] = this.GameStatus.currentSongTime;
 
             if (beatmapJSON["color"] == null) {
                 beatmapJSON["color"] = new JSONObject();
@@ -219,6 +218,7 @@ namespace HttpSiraStatus
             performanceJSON["batteryEnergy"] = this.GameStatus.modBatteryEnergy || this.GameStatus.modInstaFail ? (JSONNode)new JSONNumber(this.GameStatus.batteryEnergy) : (JSONNode)JSONNull.CreateOrGet();
             performanceJSON["energy"] = new JSONNumber(this.GameStatus.energy);
             performanceJSON["softFailed"] = this.GameStatus.softFailed;
+            performanceJSON["currentSongTime"] = this.GameStatus.currentSongTime;
         }
 
         private void UpdateNoteCutJSON()

--- a/protocol.md
+++ b/protocol.md
@@ -58,7 +58,6 @@ StatusObject = {
 		"maxScore": Integer, // Max score obtainable on the map with modifier multiplier
 		"maxRank": "SSS" | "SS" | "S" | "A" | "B" | "C" | "D" | "E", // Max rank obtainable using current modifiers
 		"environmentName": String, // Name of the environment this beatmap requested // TODO: list available names
-		"currentSongTime": Integer // 現在の曲の秒数です。1秒おきに更新されます。
 		"color": { // Contains colors used by this environment. If overrides were set by the player, they replace the values provided by the environment. SongCore may override the colors based on beatmap settings, including player overrides. Each color is stored as an array of three integers in the range [0..255] representing the red, green, and blue values in order.
 		"saberA": [Integer, Integer, Integer], // Color of the left saber and its notes
 		"saberB": [Integer, Integer, Integer], // Color of the right saber and its notes
@@ -83,6 +82,7 @@ StatusObject = {
 		"multiplier": Integer, // Current combo multiplier {1, 2, 4, 8}
 		"multiplierProgress": Number, // Current combo multiplier progress [0..1)
 		"batteryEnergy": null | Integer, // Current amount of battery lives left. null if Battery Energy and Insta Fail are disabled.
+		"currentSongTime": Integer // 現在の曲の秒数です。1秒おきに更新されます。
 	},
 	"mod": {
 		"multiplier": Number, // Current score multiplier for gameplay modifiers


### PR DESCRIPTION
5.3.0で追加したcurrentSongTimeですが、beatmapで送るとsongCoverがあって重いので、
performanceで送るように変更しました。
songCoverはカバー画像をPNGに変換してbase64で送るので、(bsr af1f)とかだと24MBぐらいあります
32GBではクリアする前に、メモリ不足でビーセイが落ちました🤣

あと、ビルド環境がOculus版に依存しているので、それも修正しています。